### PR TITLE
use small avatar

### DIFF
--- a/src/components/github/Owner/index.tsx
+++ b/src/components/github/Owner/index.tsx
@@ -21,7 +21,7 @@ const Owner = ({owner, size = '1em'}: GithubOwner) => {
     >
       <Avatar
         alt={owner}
-        src={`https://github.com/${owner}.png`}
+        src={`https://github.com/${owner}.png?size=20`}
         sx={{width: size, height: size}}
       />
       <Typography>


### PR DESCRIPTION
另外一个问题是，现在使用的avatar url是 https://github.com/{repo_name}.png

比如：https://github.com/Trenly.png
这种格式的url会在前端经过一次302跳转到 https://avatars.githubusercontent.com/u/12611259?v=4

如果在API接口查出org_id，给前端返回 `/u/12611259?size=20` 这种格式url会更快一些 